### PR TITLE
Fix issue 14 by increasing Tiktok rate limit

### DIFF
--- a/config.json
+++ b/config.json
@@ -45,8 +45,8 @@
             "type": "social"
         },
         "tiktok": {
-            "rate_limit": 1000,
-            "format": "https://www.tiktok.com/@{permutation}",
+            "rate_limit": 1500,
+            "format": "https://www.tiktok.com/@{permutation}?",
             "type": "social"
         },
         "instagram": {


### PR DESCRIPTION
The problem of false positives seemed to come from a rate limit too low for TikTok, I made several tests by increasing the value from 1000ms to 1500ms and the result was conclusive.